### PR TITLE
Don't build drafts by default

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -6,7 +6,7 @@ import shutil
 from click.testing import CliRunner
 from htmd.cli import build
 
-from utils import remove_fields_from_example_post, SUCCESS_REGEX
+from utils import remove_fields_from_post, SUCCESS_REGEX
 
 
 def test_build(run_start: CliRunner) -> None:
@@ -17,7 +17,7 @@ def test_build(run_start: CliRunner) -> None:
 
 def test_build_verify_fails(run_start: CliRunner) -> None:
     expected_output = 'Post "example" does not have field title.\n'
-    remove_fields_from_example_post(('title',))
+    remove_fields_from_post('example', ('title',))
     result = run_start.invoke(build)
     assert result.exit_code == 1
     assert result.output == expected_output

--- a/tests/test_post_dates.py
+++ b/tests/test_post_dates.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from click.testing import CliRunner
 from htmd.cli import build
 
-from utils import remove_fields_from_example_post
+from utils import remove_fields_from_post
 
 
 def test_build_post_404_invalid_date_year(run_start: CliRunner) -> None:
@@ -263,7 +263,7 @@ def test_build_published_time_is_added(run_start: CliRunner) -> None:
     # build will add it
     # verify that time is not there
     # ensure correct time is added
-    remove_fields_from_example_post(('updated',))
+    remove_fields_from_post('example', ('updated',))
     example_path = Path('posts') / 'example.md'
     with example_path.open('r') as post_file:
         b_lines = post_file.readlines()
@@ -311,7 +311,7 @@ def test_build_updated_is_added(run_start: CliRunner) -> None:
     then build will add updated with time.
     """
     # Remove updated from example post
-    remove_fields_from_example_post(('updated',))
+    remove_fields_from_post('example', ('updated',))
     # First build adds time to published
     result = run_start.invoke(build)
     assert result.exit_code == 0
@@ -369,7 +369,7 @@ def test_build_updated_is_added_once(run_start: CliRunner) -> None:
 
 
 def test_build_without_published(run_start: CliRunner) -> None:
-    remove_fields_from_example_post(('published', 'updated'))
+    remove_fields_from_post('example', ('published', 'updated'))
 
     # First build adds published time
     result = run_start.invoke(build)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from click.testing import CliRunner
 from htmd.cli import verify
 
-from utils import remove_fields_from_example_post
+from utils import remove_fields_from_post
 
 
 def test_verify(run_start: CliRunner) -> None:
@@ -15,7 +15,7 @@ def test_verify(run_start: CliRunner) -> None:
 
 def test_verify_author_missing(run_start: CliRunner) -> None:
     # Remove author from example post
-    remove_fields_from_example_post(('author',))
+    remove_fields_from_post('example', ('author',))
 
     result = run_start.invoke(verify)
     assert result.exit_code == 1
@@ -25,7 +25,7 @@ def test_verify_author_missing(run_start: CliRunner) -> None:
 
 def test_verify_title_missing(run_start: CliRunner) -> None:
     # Remove title from example post
-    remove_fields_from_example_post(('title',))
+    remove_fields_from_post('example', ('title',))
 
     result = run_start.invoke(verify)
     assert result.exit_code == 1
@@ -35,7 +35,7 @@ def test_verify_title_missing(run_start: CliRunner) -> None:
 
 def test_verify_published_missing(run_start: CliRunner) -> None:
     # Remove published from example post
-    remove_fields_from_example_post(('published',))
+    remove_fields_from_post('example', ('published',))
 
     result = run_start.invoke(verify)
     # verify doesn't check for published

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,8 +7,8 @@ SUCCESS_REGEX = (
 )
 
 
-def remove_fields_from_example_post(field_names: tuple[str, ...]) -> None:
-    example_post_path = Path('posts') / 'example.md'
+def remove_fields_from_post(path: str, field_names: tuple[str, ...]) -> None:
+    example_post_path = Path('posts') / f'{path}.md'
     with example_post_path.open('r') as post:
         lines = post.readlines()
     with example_post_path.open('w') as post:


### PR DESCRIPTION
A draft will only be built if it has draft: build
during build the metadata line will become draft: build|uuid with the uuid where you can access the draft (/draft/uuid/index.html) in the build.